### PR TITLE
Add negate condition of equipped and their alias worn/unworn

### DIFF
--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -408,8 +408,8 @@ Roids.Keywords = {
         return not Roids.HasWeaponEquipped(conditionals.equipped);
     end,
 
-    worn = equipped
-    noworn = noequipped
+    worn = equipped,
+    noworn = noequipped,
     
     dead = function(conditionals)
         return UnitIsDeadOrGhost(conditionals.target);

--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -407,6 +407,9 @@ Roids.Keywords = {
     noequipped = function(conditionals)
         return not Roids.HasWeaponEquipped(conditionals.equipped);
     end,
+
+    worn = equipped
+    noworn = noequipped
     
     dead = function(conditionals)
         return UnitIsDeadOrGhost(conditionals.target);

--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -404,6 +404,10 @@ Roids.Keywords = {
         return Roids.HasWeaponEquipped(conditionals.equipped);
     end,
     
+    noequipped = function(conditionals)
+        return not Roids.HasWeaponEquipped(conditionals.equipped);
+    end,
+    
     dead = function(conditionals)
         return UnitIsDeadOrGhost(conditionals.target);
     end,

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -95,7 +95,7 @@ This is a list of all Chat Commands that support conditions:
 * [combat / nocombat](conditions/combat.md)
 * [cooldown / nocooldown](conditions/cooldown.md)
 * [dead / nodead](conditions/dead.md)
-* [equipped](conditions/equipped.md)
+* [equipped / noquipped / worn / noworn](conditions/equipped.md)
 * [group](conditions/group.md)
 * [help / harm](conditions/help_harm.md)
 * [(my)hp](conditions/hp.md)

--- a/docs/conditions/equipped.md
+++ b/docs/conditions/equipped.md
@@ -1,6 +1,6 @@
-# equipped
+# equipped / noequipped / worn / noworn
 
-Ensures that the given item type is equipped.
+Ensures that the given item type is equipped/worn. Can be inverted by adding `no` in front of `equipped` or `worn`
 
 ## Parameters
 


### PR DESCRIPTION
I didn't find support for use cases of `/stopcasting [noworn:Shields]`. This adds support of `noequipped`, `worn` and `unworn`. Tested and works as expected.